### PR TITLE
hero css and paragraph twig updates

### DIFF
--- a/css/paragraphs/hero-unit.css
+++ b/css/paragraphs/hero-unit.css
@@ -8,15 +8,15 @@
   margin-bottom: 1em;
 }
 
-.paragraph.paragraph--type--hero-unit.size-full-width {
+.paragraph.paragraph--type--hero-unit.size-large {
   padding: 100px 2rem;
 }
 
-.paragraph.paragraph--type--hero-unit.size-full-width h2 {
+.paragraph.paragraph--type--hero-unit.size-large h2 {
   font-size: 250%;
 }
 
-.paragraph.paragraph--type--hero-unit.size-large {
+.paragraph.paragraph--type--hero-unit.size-medium {
   padding: 2rem;
 }
 

--- a/templates/paragraphs/paragraph--hero-unit.html.twig
+++ b/templates/paragraphs/paragraph--hero-unit.html.twig
@@ -31,11 +31,11 @@
 
 {# set classes for the size of the component #}
 {% if paragraph.field_size.value is same as("0") %}
-  {% set size = "size-full-width" %}
-{% elseif paragraph.field_size.value is same as("1") %}
-  {% set size = "size-small" %}
-{% else %}
   {% set size = "size-large" %}
+{% elseif paragraph.field_size.value is same as("1") %}
+  {% set size = "size-medium" %}
+{% else %}
+  {% set size = "size-small" %}
 {% endif %}
 
 {% block paragraph %}


### PR DESCRIPTION
hero-unit css class naming updates
hero-unit twig paragraph change to make it match new css names

Merging this without updating the base theme's hero paragraph settings will break the Hero option. 
They will need to be tested at the same time.

This is in part for issue #71 