### PR TITLE
Title Render Fix

### DIFF
--- a/templates/paragraphs/paragraph--content-grid.html.twig
+++ b/templates/paragraphs/paragraph--content-grid.html.twig
@@ -52,14 +52,14 @@
                   {% endif %}
                 </div>
               {% endif %}
-              {% if (item.entity.field_grid_layout_content_title|view) or (item.entity.field_grid_layout_content_text|view) %}
+              {% if (item.entity.field_grid_layout_content_title.value|render|striptags|trim) or (item.entity.field_grid_layout_content_text|view) %}
                 <div class="grid-text-container">
                   {% if item.entity.field_grid_layout_content_link.0.url|render %}
                     <a href=" {{ gridLink }} ">
-                    <h3>{{item.entity.field_grid_layout_content_title|view}}</h3>
+                    <h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
                     </a>
                   {% else %}
-                    <h3>{{item.entity.field_grid_layout_content_title|view}}</h3>
+                    <h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
                   {% endif %}
                   {{item.entity.field_grid_layout_content_text|view}}
                 </div>
@@ -86,14 +86,14 @@
                   {% endif %}
                 </div>
               {% endif %}
-              {% if (item.entity.field_grid_layout_content_title|view) or (item.entity.field_grid_layout_content_text|view) %}
+              {% if (item.entity.field_grid_layout_content_title.value|render|striptags|trim) or (item.entity.field_grid_layout_content_text|view) %}
                 <div class="grid-text-container">
                   {% if item.entity.field_grid_layout_content_link.0.url|render %}
                     <a href=" {{ gridLink }} ">
-                    <h3>{{item.entity.field_grid_layout_content_title|view}}</h3>
+                    <h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
                     </a>
                   {% else %}
-                    <h3>{{item.entity.field_grid_layout_content_title|view}}</h3>
+                    <h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
                   {% endif %}
                   {{item.entity.field_grid_layout_content_text|view}}
                 </div>
@@ -114,11 +114,11 @@
                   {% if item.entity.field_grid_layout_content_link.0.url|render %}
                     <a href=" {{ gridLink }} ">
                     {{ item.entity.field_grid_layout_content_image|view }}
-                    <h3>{{item.entity.field_grid_layout_content_title|view}}</h3>
+                    <h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
                     </a>
                   {% else %}
                     {{ item.entity.field_grid_layout_content_image|view }}
-                    <h3>{{item.entity.field_grid_layout_content_title|view}}</h3>
+                    <h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
                   {% endif %}
                 </div>
               {% endif %}
@@ -150,14 +150,14 @@
                   {% endif %}
                   </div>
                 {% endif %}
-                {% if (item.entity.field_grid_layout_content_title|view) or (item.entity.field_grid_layout_content_text|view) %}
+                {% if (item.entity.field_grid_layout_content_title.value|render|striptags|trim) or (item.entity.field_grid_layout_content_text|view) %}
                   <div class="grid-text-container">
                   {% if item.entity.field_grid_layout_content_link.0.url|render %}
                     <a href=" {{ gridLink }} ">
-                    <h3>{{item.entity.field_grid_layout_content_title|view}}</h3>
+                    <h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
                     </a>
                   {% else %}
-                    <h3>{{item.entity.field_grid_layout_content_title|view}}</h3>
+                    <h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
                   {% endif %}
                     {{item.entity.field_grid_layout_content_text|view}}
                   </div>
@@ -178,14 +178,14 @@
                   {% endif %}
                     </div>
                   {% endif %}
-                  {% if (item.entity.field_grid_layout_content_title|view) or (item.entity.field_grid_layout_content_text|view) %}
+                  {% if (item.entity.field_grid_layout_content_title.value|render|striptags|trim) or (item.entity.field_grid_layout_content_text|view) %}
                     <div class="grid-text-container">
                   {% if item.entity.field_grid_layout_content_link.0.url|render %}
                     <a href=" {{ gridLink }} ">
-                    <h3>{{item.entity.field_grid_layout_content_title|view}}</h3>
+                    <h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
                     </a>
                   {% else %}
-                    <h3>{{item.entity.field_grid_layout_content_title|view}}</h3>
+                    <h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
                   {% endif %}
                       {{item.entity.field_grid_layout_content_text|view}}
                     </div>
@@ -206,14 +206,14 @@
                       {% endif %}
                     </div>
                   {% endif %}
-                  {% if (item.entity.field_grid_layout_content_title|view) or (item.entity.field_grid_layout_content_text|view) %}
+                  {% if (item.entity.field_grid_layout_content_title.value|render|striptags|trim) or (item.entity.field_grid_layout_content_text|view) %}
                     <div class="grid-text-container">
                   {% if item.entity.field_grid_layout_content_link.0.url|render %}
                     <a href=" {{ gridLink }} ">
-                    <h3>{{item.entity.field_grid_layout_content_title|view}}</h3>
+                    <h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
                     </a>
                   {% else %}
-                    <h3>{{item.entity.field_grid_layout_content_title|view}}</h3>
+                    <h3>{{item.entity.field_grid_layout_content_title.value|render|striptags|trim}}</h3>
                   {% endif %}
                       {{item.entity.field_grid_layout_content_text|view}}
                     </div>

--- a/templates/paragraphs/paragraph--content-row.html.twig
+++ b/templates/paragraphs/paragraph--content-row.html.twig
@@ -39,10 +39,10 @@
             <div class="col-8 row-text-container">
                 {% if item.entity.field_row_layout_content_link.0.url|render %}
                   <a href=" {{ rowLink }} ">
-                  <h3>{{item.entity.field_row_layout_content_title|view}}</h3>
+                  <h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
                   </a>
                 {% else %}
-                  <h3>{{item.entity.field_row_layout_content_title|view}}</h3>
+                  <h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
                 {% endif %}
                 {{item.entity.field_row_layout_content_text|view}}
             </div>
@@ -66,10 +66,10 @@
             <div class="col-8 row-text-container">
               {% if item.entity.field_row_layout_content_link.0.url|render %}
                 <a href=" {{ rowLink }} ">
-                <h3>{{item.entity.field_row_layout_content_title|view}}</h3>
+                <h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
                 </a>
               {% else %}
-                <h3>{{item.entity.field_row_layout_content_title|view}}</h3>
+                <h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
               {% endif %}
               {{item.entity.field_row_layout_content_text|view}}
             </div>
@@ -77,10 +77,10 @@
             <div class="col-8 row-text-container">
               {% if item.entity.field_row_layout_content_link.0.url|render %}
                 <a href=" {{ rowLink }} ">
-                <h3>{{item.entity.field_row_layout_content_title|view}}</h3>
+                <h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
                 </a>
               {% else %}
-                <h3>{{item.entity.field_row_layout_content_title|view}}</h3>
+                <h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
               {% endif %}
               {{item.entity.field_row_layout_content_text|view}}
             </div>
@@ -114,10 +114,10 @@
             <div class="col-6 row-text-container">
               {% if item.entity.field_row_layout_content_link.0.url|render %}
                 <a href=" {{ rowLink }} ">
-                <h3>{{item.entity.field_row_layout_content_title|view}}</h3>
+                <h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
                 </a>
               {% else %}
-                <h3>{{item.entity.field_row_layout_content_title|view}}</h3>
+                <h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
               {% endif %}
               {{item.entity.field_row_layout_content_text|view}}
             </div>
@@ -125,10 +125,10 @@
             <div class="col-6 row-text-container">
               {% if item.entity.field_row_layout_content_link.0.url|render %}
                 <a href=" {{ rowLink }} ">
-                <h3>{{item.entity.field_row_layout_content_title|view}}</h3>
+                <h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
                 </a>
               {% else %}
-                <h3>{{item.entity.field_row_layout_content_title|view}}</h3>
+                <h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
               {% endif %}
               {{item.entity.field_row_layout_content_text|view}}
             </div>
@@ -163,10 +163,10 @@
                       <div class="feature-row-text">
                           {% if item.entity.field_row_layout_content_link.0.url|render %}
                             <a href=" {{ rowLink }} ">
-                            <h3>{{item.entity.field_row_layout_content_title|view}}</h3>
+                            <h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
                             </a>
                           {% else %}
-                            <h3>{{item.entity.field_row_layout_content_title|view}}</h3>
+                            <h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
                           {% endif %}
                           {{ item.entity.field_row_layout_content_text|view }}
                       </div>
@@ -179,10 +179,10 @@
                         <div class="feature-row-text">
                             {% if item.entity.field_row_layout_content_link.0.url|render %}
                               <a href=" {{ rowLink }} ">
-                              <h3>{{item.entity.field_row_layout_content_title|view}}</h3>
+                              <h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
                               </a>
                             {% else %}
-                              <h3>{{item.entity.field_row_layout_content_title|view}}</h3>
+                              <h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
                             {% endif %}
                             {{ item.entity.field_row_layout_content_text|view }}
                         </div>
@@ -194,10 +194,10 @@
                         <div class="feature-row-text">
                             {% if item.entity.field_row_layout_content_link.0.url|render %}
                               <a href=" {{ rowLink }} ">
-                              <h3>{{item.entity.field_row_layout_content_title|view}}</h3>
+                              <h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
                               </a>
                             {% else %}
-                              <h3>{{item.entity.field_row_layout_content_title|view}}</h3>
+                              <h3>{{item.entity.field_row_layout_content_title.value|render|striptags|trim}}</h3>
                             {% endif %}
                             {{ item.entity.field_row_layout_content_text|view }}
                         </div>


### PR DESCRIPTION
Fixed titles not rendering their text properly.
Uses a .value|render instead of |ivew on the plain text field.

To test:
1) make basic page
2) make content grid & content row
3) populate with title to have an apostrophe or something in that vein
4) profit

Closes #172 