### PR TITLE
chg: Removing CSS for CKEditor 4

### DIFF
--- a/ucb2021_base.info.yml
+++ b/ucb2021_base.info.yml
@@ -9,10 +9,6 @@ libraries:
   - ucb2021_base/ucb-global
   - ucb2021_base/ucb-paragraphs
 
-ckeditor_stylesheets:
-  - css/styleguide/type.css
-  - css/fontawesome/all.min.css
-
 regions:
   header: "Header"
   primary_menu: "Main Menu"


### PR DESCRIPTION
Removing CSS that was used for CKEditor 4 as we're switching to CKEditor 5 in the profile.  Test along with branch issue/184 in the profile.  