### PR TITLE
[Issue 100] Adds Rave alerts to theme

### DIFF
--- a/config/install/ucb2021_base.settings.yml
+++ b/config/install/ucb2021_base.settings.yml
@@ -11,6 +11,7 @@ ucb_campus_header_color: '1'
 ucb_header_color: '3'
 ucb_sidebar_position: '0'
 ucb_be_boulder: '1'
+ucb_rave_alerts: true
 ucb_gtm_account: ''
 ucb_secondary_menu: 0
 ucb_footer_menu: 0

--- a/css/style.css
+++ b/css/style.css
@@ -132,6 +132,20 @@ input[type="submit"] {
   padding: 0.25em;
 }
 
+.ucb-alert {
+	text-align: center;
+	border-radius: 0;
+	width: 100%;
+	margin: 0;
+}
+
+.ucb-alert-link:link, .ucb-alert-link:visited {
+	text-decoration: underline;
+	text-decoration-color: #6a1a21;
+	-webkit-text-decoration-color: #6a1a21;
+	white-space: nowrap;
+}
+
 header#ucb-header-block {
   background: black;
   padding: 1em 0;

--- a/js/ucb-rave-alert.js
+++ b/js/ucb-rave-alert.js
@@ -1,0 +1,45 @@
+/**
+ * Containes the Rave Alert web component.
+ */
+
+class RaveAlertElement extends HTMLElement {
+	constructor() {
+		super();
+		const feedURL = new URL(this.getAttribute('feed'));
+		fetch(feedURL, {method: 'GET'})
+			.then(response => response.text())
+			.then(responseText => new DOMParser().parseFromString(responseText, 'text/xml'))
+			.then(responseDocument => {
+				const
+					itemElement = responseDocument.getElementsByTagName('item')[0],
+					titleText = itemElement.getElementsByTagName('title')[0].childNodes[0].nodeValue,
+					descriptionText = itemElement.getElementsByTagName('description')[0].childNodes[0].nodeValue,
+					linkText = itemElement.getElementsByTagName('link')[0].childNodes[0] ? itemElement.getElementsByTagName('link')[0].childNodes[0].nodeValue : '';
+				if(titleText.indexOf('[CLEAR]') == -1) // This means there's an active alert to show.
+					this.build(descriptionText, linkText);
+			});
+	}
+
+	build(descriptionText, linkText) {
+		linkText = linkText || this.getAttribute('link') || 'https://alerts.colorado.edu';
+		const
+			alertElement = document.createElement('div'),
+			alertTextElement = document.createElement('span'),
+			alertLinkElement = document.createElement('a');
+		alertElement.className = 'alert alert-danger alert-dismissible fade show ucb-alert ucb-rave-alert';
+		alertElement.setAttribute('role', 'alert');
+		alertTextElement.className = 'ucb-alert-text ucb-rave-alert-text';
+		alertLinkElement.className = 'alert-link ucb-alert-link ucb-rave-alert-link';
+		alertTextElement.innerText = descriptionText;
+		alertLinkElement.target = '_blank';
+		alertLinkElement.href = linkText;
+		alertLinkElement.innerText = 'Learn more';
+		alertElement.appendChild(alertTextElement);
+		alertElement.innerHTML += ' ';
+		alertElement.appendChild(alertLinkElement);
+		alertElement.innerHTML += '<button type="button" class="btn-close ucb-alert-close ucb-rave-alert-close" data-bs-dismiss="alert" aria-label="Close"></button>';
+		this.appendChild(alertElement);
+	}
+}
+
+customElements.define('rave-alert', RaveAlertElement);

--- a/templates/layout/html.html.twig
+++ b/templates/layout/html.html.twig
@@ -44,7 +44,7 @@
                     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
                 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','{{ uccs_gtm_account }}');</script>
+            })(window,document,'script','dataLayer','{{ ucb_gtm_account }}');</script>
         <!-- End Google Tag Manager -->
     {% endif %}
 
@@ -58,9 +58,9 @@
 <a href="#main-content" class="visually-hidden focusable">
     {{ 'Skip to main content'|t }}
 </a>
-{% if uccs_gtm_account|trim is not empty %}
+{% if ucb_gtm_account|trim is not empty %}
 <!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ uccs_gtm_account }}"
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ ucb_gtm_account }}"
                   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
 {% endif %}

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -88,6 +88,10 @@
     {% set header_color = 'dark' %}
   {% endif %}
 
+	{% if ucb_rave_alerts %}
+		<rave-alert feed="https://www.getrave.com/rss/cuboulder/channel1" link="https://alerts.colorado.edu"></rave-alert>
+	{% endif %}
+
   {{ page.header }}
   <div class="page-header">
   {% if user.hasPermission('access administration pages') %}

--- a/ucb2021_base.libraries.yml
+++ b/ucb2021_base.libraries.yml
@@ -18,6 +18,7 @@ ucb-global:
     js/bootstrap/bootstrap.bundle.min.js: {}
     js/fontawesome/all.min.js: {}
     js/ucb-main.js: {}
+    js/ucb-rave-alert.js: {}
   dependencies:
     - core/drupal
     - core/jquery

--- a/ucb2021_base.theme
+++ b/ucb2021_base.theme
@@ -58,6 +58,7 @@ function ucb2021_base_preprocess_page(array &$variables) {
   $variables['ucb_header_color'] = theme_get_setting('ucb_header_color');
   $variables['ucb_be_boulder'] = theme_get_setting('ucb_be_boulder');
   $variables['ucb_social_share_position'] = theme_get_setting('ucb_social_share_position');
+  $variables['ucb_rave_alerts'] = theme_get_setting('ucb_rave_alerts');
 
   // check to see if we're on the homepage or not
   try {

--- a/ucb2021_base.theme
+++ b/ucb2021_base.theme
@@ -125,95 +125,17 @@ function ucb2021_base_preprocess_node__organization(array &$variables) {
 /***
  *  Custom theme settings worker function
  ***/
-function ucb2021_base_form_system_theme_settings_alter(&$form, \Drupal\Core\Form\FormStateInterface &$form_state, $form_id = NULL)
-{
+function ucb2021_base_form_system_theme_settings_alter(&$form, \Drupal\Core\Form\FormStateInterface &$form_state, $form_id = NULL) {
   // Work-around for a core bug affecting admin themes. See issue #943212.
   if (isset($form_id)) {
     return;
   }
-
-  $form['ucb_campus_header_color'] = array(
-    '#type'         => 'select',
-    '#title'        => t('CU Boulder campus header color'),
-    '#default_value'    => theme_get_setting('ucb_campus_header_color'),
-    '#options'          => array(
-      t('Black'),
-      t('White'),
-    ),
-    '#description'      => t("Select the color for the header background for the campus branding information at the top of the page."),
-  );
-
-  $form['ucb_header_color'] = array(
-    '#type'         => 'select',
-    '#title'        => t('CU Boulder site header color'),
-    '#default_value'    => theme_get_setting('ucb_header_color'),
-    '#options'          => array(
-      t('Black'),
-      t('White'),
-      t('Light'),
-      t('Dark'),
-    ),
-    '#description'      => t("Select the color for the header background for the site information at the top of the page."),
-  );
-
-  $form['ucb_sidebar_position'] = array(
-    '#type'           => 'select',
-    '#title'          => t('Where to show sidebar content on a page'),
-    '#default_value'    => 'Left',
-    '#options'        => array(
-      t('Left'),
-      t('Right'),
-    ),
-    '#description'    => t("Select if sidebar content should appear on the left or right side of a page."),
-  );
-
-  $form['ucb_be_boulder'] = array(
-    '#type'           => 'select',
-    '#title'          => t('Where to display the Be Boulder slogan on the site.'),
-    '#default_value'    => theme_get_setting('ucb_be_boulder'),
-    '#options'        => array(
-      t('None'),
-      t('Footer'),
-      t('Header'),
-    ),
-    '#description'    => t("Check this box if you would like to display the 'Be Boulder' slogan in the header."),
-  );
-
-  $form['ucb_gtm_account'] = array(
-    '#type'             => 'textfield',
-    '#title'            => t('GTM Account Number'),
-    '#default_value'    => theme_get_setting('ucb_gtm_account'),
-    '#description'      => t('Google Tag Manager account number e.g. GTM-123456.'),
-  );
-
-  $form['ucb_secondary_menu'] = array(
-    '#type'           => 'checkbox',
-    '#title'          => t('Display the standard Boulder secondary menu in the header navigation region.'),
-    '#default_value'    => theme_get_setting('ucb_secondary_menu'),
-    '#description'    => t("Check this box if you would like to display the default Boulder secondary menu links in the header."),
-  );
-
-  $form['ucb_footer_menu'] = array(
-    '#type'           => 'checkbox',
-    '#title'          => t('Display the standard Boulder menus in the header footer region.'),
-    '#default_value'    => theme_get_setting('ucb_footer_menu'),
-    '#description'    => t("Check this box if you would like to display the default Boulder footer menu links in the footer."),
-  );
-// Choose where social share buttons are positioned on each page
-  $form['ucb_social_share_position'] = array(
-    '#type'           => 'select',
-    '#title'          => t('Where your social media sharing links render'),
-    '#default_value'    => theme_get_setting('ucb_social_share_position'),
-    '#options'        => array(
-      t('None'),
-      t('Left Side (Desktop) / Below Title (Mobile)'),
-      t('Left Side (Desktop) / Below Content (Mobile)'),
-      t('Below Content'),
-      t('Below Title'),
-    ),
-
-    '#description'    => t("Select the location for social sharing links (Facebook, Twitter, etc) to appear on your pages."),
-  );
-
+  if(\Drupal::service('module_handler')->moduleExists('ucb_site_configuration')) {
+	// This call relies on the module dependency `ucb_site_configuration`.
+	// It uses the function `buildThemeSettingsForm` in the module to build the theme settings form.
+	\Drupal::service('ucb_site_configuration')->buildThemeSettingsForm($form, $form_state);
+  } else {
+	\Drupal::service('messenger')->addError('Module `CU Boulder Site Configuration`, required to display the CU Boulder theme settings form, isn\'t installed.');
+  }
 }
 


### PR DESCRIPTION
To test, change the feed URL from `https://www.getrave.com/rss/cuboulder/channel1` to `https://www.getrave.com/rss/DemoUniversityAlert/channel8`. This may be done in either `page.html.twig` or by creating a new `<rave-alert>` element using Inspect Element in the browser.